### PR TITLE
Preserve the original `i18n_key` value when overriding `ActiveModel::Model.model_name`

### DIFF
--- a/lib/dfe/wizard/step.rb
+++ b/lib/dfe/wizard/step.rb
@@ -9,7 +9,10 @@ module DfE
       delegate :store, :url_helpers, to: :wizard
 
       def self.model_name
-        ActiveModel::Name.new(self, nil, formatted_name.demodulize)
+        original_i18n_key = super.i18n_key
+        model_name = ActiveModel::Name.new(self, nil, formatted_name.demodulize)
+        model_name.i18n_key = original_i18n_key
+        model_name
       end
 
       def self.formatted_name

--- a/spec/dfe/wizard/step_spec.rb
+++ b/spec/dfe/wizard/step_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe DfE::Wizard::Step do
     it 'returns the name demodulized' do
       expect(described_class.model_name).to eq('Wizard')
     end
+
+    it 'returns the name with original i18n key' do
+      expect(described_class.model_name.i18n_key).to eq(:'dfe/wizard/step')
+    end
   end
 
   describe '.formatted_name' do


### PR DESCRIPTION
## Context

See this issue https://github.com/DFE-Digital/dfe-wizard/issues/1 for initial discussion.

Wizard steps usually contain validations and hence i18n translations to produce human readable messages about invalid attribute values. 
I18n keys rely on the method `model_name.i18n_key` and the default `ActiveModel` implementation uses module names to namespace the key. 
eg. `RootModule::SubModule::SomeStep` would produce the i18n key `:root_module/sub_module/some_step`

## Changes

This PR ensures this namespaced i18n key behaviour is preserved while still producing the demodulized model name implementation that `DfE::Wizard::Step` relies on.

This change will have an impact on existing projects using the gem as the i18n locale files won't contain namespaced step keys, resulting in missing translations.