### PR TITLE
Use default_path_arguments in current_step_path

### DIFF
--- a/lib/dfe/wizard/base.rb
+++ b/lib/dfe/wizard/base.rb
@@ -114,8 +114,12 @@ module DfE
         end
       end
 
-      def current_step_path(args = nil)
+      def current_step_path(args = current_step_path_arguments)
         url_helpers.public_send("#{current_step.class.route_name}_path", args)
+      end
+
+      def current_step_path_arguments
+        default_path_arguments if respond_to?(:default_path_arguments)
       end
 
       def url_helpers

--- a/spec/dfe/wizard/base_spec.rb
+++ b/spec/dfe/wizard/base_spec.rb
@@ -180,6 +180,53 @@ RSpec.describe DfE::Wizard::Base do
     end
   end
 
+  describe '#current_step_path_arguments' do
+    let(:default_path_arguments) { { arg: 123 } }
+
+    context 'when defaults are defined' do
+      before do
+        allow(wizard).to receive(:default_path_arguments).and_return(default_path_arguments)
+      end
+
+      it 'returns defaults' do
+        expect(wizard.current_step_path_arguments).to eq(default_path_arguments)
+      end
+    end
+
+    context 'when defaults are undefined' do
+      it { expect(wizard.current_step_path_arguments).to be_nil }
+    end
+  end
+
+  describe '#current_step_path' do
+    let(:current_step) { :test_go_to_find }
+
+    context 'when default arguments are defined' do
+      before do
+        without_partial_double_verification do
+          allow(wizard).to receive(:default_path_arguments).and_return({ arg: 123 })
+          allow(url_helpers).to receive(:test_wizard_test_go_to_find_path).with({ arg: 123 }).and_return('/current-path?arg=123')
+        end
+      end
+
+      it 'includes default_path_arguments' do
+        expect(wizard.current_step_path).to eq('/current-path?arg=123')
+      end
+    end
+
+    context 'when default arguments are not defined' do
+      before do
+        without_partial_double_verification do
+          allow(url_helpers).to receive(:test_wizard_test_go_to_find_path).with(nil).and_return('/current-path')
+        end
+      end
+
+      it 'has no arguments' do
+        expect(wizard.current_step_path).to eq('/current-path')
+      end
+    end
+  end
+
   describe '#previous_step_path' do
     let(:current_step) { :test_do_you_know_which_course }
 


### PR DESCRIPTION
The `current_step_path` does not use the `default_path_arguments`. 

Here is an example in the wild:
https://github.com/DFE-Digital/register-early-career-teachers-public/pull/1253

Which needed the following to work:
https://github.com/DFE-Digital/register-early-career-teachers-public/blob/e6146b578e89a802cf5f094812147ab03a4b1551/app/wizards/schools/ects/wizard.rb#L20-L27