### PR TITLE
Fix require error for steps processor base

### DIFF
--- a/lib/dfe/wizard.rb
+++ b/lib/dfe/wizard.rb
@@ -179,6 +179,10 @@ module DfE
     #
     # @api public
     module StepsProcessor
+      # Base step processor
+      # @api public
+      autoload :Base, 'dfe/wizard/steps_processor/base'
+
       # Graph-based step processor
       # @api public
       autoload :Graph, 'dfe/wizard/steps_processor/graph'


### PR DESCRIPTION
Fix require error:

```
lib/dfe/wizard/steps_processor/graph/dsl.rb:4:in `<module:StepsProcessor>': uninitialized constant DfE::Wizard::StepsProcessor::Base (NameError)

      class Graph < Base
                    ^^^^
```

Tests didn't pick up this because the class was already loaded