### PR TITLE
Add model repository to the autoload

### DIFF
--- a/lib/dfe/wizard.rb
+++ b/lib/dfe/wizard.rb
@@ -139,10 +139,11 @@ module DfE
     # @api public
     module Repository
       autoload :Base, 'dfe/wizard/repository/base'
-      autoload :InMemory, 'dfe/wizard/repository/in_memory'
-      autoload :Session, 'dfe/wizard/repository/session'
-      autoload :Redis, 'dfe/wizard/repository/redis'
       autoload :Cache, 'dfe/wizard/repository/cache'
+      autoload :InMemory, 'dfe/wizard/repository/in_memory'
+      autoload :Model, 'dfe/wizard/repository/model'
+      autoload :Redis, 'dfe/wizard/repository/redis'
+      autoload :Session, 'dfe/wizard/repository/session'
       autoload :WizardState, 'dfe/wizard/repository/wizard_state'
     end
     # @!endgroup


### PR DESCRIPTION
## Context

Model repository wasn't added to the autoload leading devs to add the manual require in their apps.

Adding autoload fix this need.

Also sorting the autoload alphabetically. 