### PR TITLE
Add release plumbing for tag-based distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# The annotated tag is the release: consumers install with
+# `github: 'DFE-Digital/dfe-wizard', tag: 'vX.Y.Z'`. This workflow turns that
+# tag into a GitHub Release. Nothing is pushed to RubyGems. See RELEASING.md.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  guard:
+    name: Tag matches gem version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Compare tag against Dfe::Wizard::VERSION
+        id: check
+        run: |
+          version="$(ruby -Ilib -e 'require "dfe/wizard/version"; print Dfe::Wizard::VERSION')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ "$GITHUB_REF_NAME" != "v$version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match Dfe::Wizard::VERSION ($version). The version lives in lib/dfe/wizard/version.rb and README.md — see RELEASING.md."
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches version $version."
+
+  test:
+    name: Test
+    needs: guard
+    uses: ./.github/workflows/test.yml
+
+  release:
+    name: Publish GitHub Release
+    needs: [guard, test]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.guard.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+
+      # An audit/air-gap artefact. The normal install path is Bundler + git,
+      # which never touches this file.
+      - name: Build gem
+        run: gem build dfe-wizard.gemspec
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          awk -v header="## [$VERSION]" '
+            index($0, header) == 1 { found = 1; next }
+            found && /^## \[/       { exit }
+            found                   { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::No '## [$VERSION]' section found in CHANGELOG.md."
+            exit 1
+          fi
+          cat RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # RubyGems prerelease versions carry a letter in the suffix
+          # (1.1.0.beta, 1.1.0.rc1); plain releases never do.
+          prerelease=""
+          case "$VERSION" in
+            *[a-zA-Z]*) prerelease="--prerelease" ;;
+          esac
+
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file RELEASE_NOTES.md \
+            --verify-tag \
+            $prerelease \
+            "dfe-wizard-$VERSION.gem"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # DfE::Wizard
 
+[![Ruby](https://github.com/DFE-Digital/dfe-wizard/actions/workflows/main.yml/badge.svg)](https://github.com/DFE-Digital/dfe-wizard/actions/workflows/main.yml)
+
 A multi-step form framework for Ruby on Rails applications.
 
 **Version**: 1.0.0.beta
+
+### Requirements
+
+| | Supported |
+|---|---|
+| Ruby | 3.2, 3.3, 3.4 |
+| Rails | 7.1, 7.2, 8.0, 8.1 |
+
+Every combination above is exercised by CI. See [RELEASING.md](RELEASING.md)
+for how to add a version.
 
 ---
 
@@ -89,7 +101,8 @@ Use DfE::Wizard when you need:
 
 ## Installation
 
-Add to your Gemfile:
+This gem is distributed via GitHub tags, not RubyGems. Pin to a tag in your
+Gemfile:
 
 ```ruby
 gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v1.0.0.beta'
@@ -100,6 +113,12 @@ Then run:
 ```bash
 bundle install
 ```
+
+Bundler resolves the tag to a commit SHA and records both in your
+`Gemfile.lock`, so builds stay reproducible. Released tags are never moved.
+
+To track unreleased work instead, swap `tag:` for `branch: 'main'` — but pin to
+a tag for anything you deploy.
 
 ---
 
@@ -2215,6 +2234,20 @@ end
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/DFE-Digital/dfe-wizard/issues)
+
+## Contributing
+
+```bash
+git clone git@github.com:DFE-Digital/dfe-wizard.git
+cd dfe-wizard
+bundle install
+(cd spec/rails-dummy && bundle install && bundle exec rails db:create db:schema:load RAILS_ENV=test)
+bundle exec rake            # rspec + rubocop
+```
+
+The suite runs against a Rails dummy app in `spec/rails-dummy` and needs
+PostgreSQL. Set `RAILS_VERSION` to develop against a different Rails — see
+[RELEASING.md](RELEASING.md), which also covers how releases are cut.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,116 @@
+# Releasing dfe-wizard
+
+## How this gem is distributed
+
+**Via GitHub tags, not RubyGems.** DfE has no RubyGems account, so consumers
+install from git:
+
+```ruby
+gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v1.0.0'
+```
+
+Bundler clones the repo, resolves the tag to a commit SHA, records **both** in
+the consuming app's `Gemfile.lock`, evaluates `dfe-wizard.gemspec` from the
+checkout, and puts `lib/` on the load path.
+
+Two things follow from that:
+
+- **The annotated tag is the release.** Everything else — the GitHub Release
+  page, the built `.gem` — is presentation.
+- **Never move a published tag.** Consumers have the SHA locked. Moving a tag
+  makes `bundle install` and `bundle update` disagree and produces failures
+  nobody can reproduce. A bad release gets a new patch version, never a re-tag.
+
+## Do not run `rake release`
+
+It is disabled in the `Rakefile`. Upstream `bundler/gem_tasks` defines it as
+tag + git push + `gem push`, which is wrong for this gem. `rake build` and
+`rake install` still work.
+
+`dfe-wizard.gemspec` also sets `allowed_push_host` to an unresolvable host, so
+a direct `gem push` fails rather than publishing under whoever is logged in.
+
+## Cutting a release
+
+1. **Bump the version.** It appears in three places and they must move
+   together:
+   - `lib/dfe/wizard/version.rb` — `Dfe::Wizard::VERSION`
+   - `README.md` — the `**Version**:` line near the top
+   - `README.md` — the `tag:` in the Installation snippet
+
+2. **Update `CHANGELOG.md`.** Add a `## [X.Y.Z] - YYYY-MM-DD` section at the
+   top. The release workflow extracts this section verbatim as the GitHub
+   Release notes and **fails if no section matches the version**, so the
+   heading has to be exact. Call out breaking changes explicitly.
+
+3. **Open a PR and get CI green.** The matrix in
+   `.github/workflows/test.yml` runs the suite across every supported
+   Ruby/Rails pair; `rubocop` runs alongside it.
+
+4. **Merge to `main`.**
+
+5. **Tag and push:**
+
+   ```bash
+   git checkout main && git pull
+   git tag -a v1.0.0 -m 'v1.0.0'
+   git push origin v1.0.0
+   ```
+
+6. **The release workflow does the rest** — it asserts the tag matches
+   `Dfe::Wizard::VERSION`, re-runs the full matrix against the tagged tree,
+   builds the `.gem`, and creates the GitHub Release with the CHANGELOG
+   section as its body and the `.gem` attached.
+
+7. **Smoke-test the real install path** in a scratch directory:
+
+   ```ruby
+   # Gemfile
+   source 'https://rubygems.org'
+   gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v1.0.0'
+   ```
+
+   ```bash
+   bundle install && bundle exec ruby -e "require 'dfe/wizard'; puts Dfe::Wizard::VERSION"
+   ```
+
+## Tag convention
+
+Annotated, `v` + the gem version, matching `v0.1.0`, `v0.1.1`, `v1.0.0.beta`.
+Prereleases keep the RubyGems suffix (`v1.1.0.beta`, `v1.1.0.rc1`); the release
+workflow detects the letter in the suffix and marks the GitHub Release as a
+prerelease automatically.
+
+## Supported Ruby and Rails versions
+
+Three things must agree, or the gem advertises support it does not test:
+
+| Where | What it says |
+|---|---|
+| `dfe-wizard.gemspec` | `required_ruby_version`, and the `activemodel`/`activesupport` range |
+| `.github/workflows/test.yml` | the `include:` matrix of Ruby/Rails pairs |
+| `README.md` | the Requirements section |
+
+To add a Rails version: add a row to the matrix `include:` list, widen the
+gemspec range if the new version falls outside it, and update the README. The
+matrix is an explicit list rather than a cross product because not every pair
+is valid — Rails 7.1 has no Ruby 3.4 support, and Rails 8.0 requires Ruby 3.2+.
+
+Locally, `RAILS_VERSION` selects the Rails to develop against. Both the root
+`Gemfile` and `spec/rails-dummy/Gemfile` read it, and both bundles must agree:
+
+```bash
+export RAILS_VERSION=8.1
+bundle install
+(cd spec/rails-dummy && bundle install && bundle exec rails db:drop db:create db:schema:load RAILS_ENV=test)
+bundle exec rspec
+```
+
+Unset it to fall back to the default. The suite needs PostgreSQL; CI provides
+it as a service container, and `DATABASE_URL` overrides the connection.
+
+Two dummy-app details exist to make the matrix work, and should stay that way:
+`spec/rails-dummy/config/application.rb` calls `load_defaults` with the running
+Rails version rather than a hardcoded one, and `spec/rails-dummy/db/schema.rb`
+is stamped at the **floor** of the supported range. Newer Rails loads an
+older-stamped schema; the reverse fails.

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,22 @@ RuboCop::RakeTask.new
 
 task default: %i[spec rubocop]
 
+# `bundler/gem_tasks` defines `release` as tag + git push + `gem push`. This
+# gem is distributed via GitHub tags only, so that task would half-run and then
+# fail at the RubyGems step with a bare connection error. Replace it with a
+# pointer to the real procedure. `rake build` and `rake install` still work.
+Rake::Task['release'].clear
+desc 'Disabled — see RELEASING.md'
+task :release do
+  abort <<~MSG
+    `rake release` is disabled.
+
+    dfe-wizard is distributed via GitHub tags, not RubyGems — DfE has no
+    RubyGems account. Releasing means pushing an annotated tag, which the
+    release workflow turns into a GitHub Release.
+
+    See RELEASING.md.
+  MSG
+end
+
 require 'dfe/wizard'

--- a/dfe-wizard.gemspec
+++ b/dfe-wizard.gemspec
@@ -11,26 +11,41 @@ Gem::Specification.new do |spec|
   spec.summary = 'Extracted from Apply - A set of design of creating multi step forms'
   spec.description = 'A solution to implement multi step forms in specific design patterns in a simple way.'
   spec.homepage = 'https://github.com/DFE-Digital/dfe-wizard'
+  spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.2.4'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['changelog_uri'] = 'https://github.com/DFE-Digital/dfe-wizard/blob/main/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
+  spec.metadata['documentation_uri'] = "#{spec.homepage}/blob/main/README.md"
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+
+  # This gem is distributed via GitHub tags, not RubyGems — DfE has no RubyGems
+  # account. Pointing at an unresolvable host makes an accidental `gem push`
+  # (including via `rake release`) fail loudly rather than publish under whoever
+  # happens to be logged in. See RELEASING.md.
+  spec.metadata['allowed_push_host'] = 'https://rubygems.org.invalid'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile]) ||
+        %w[TODO.md .rubocop.yml .rspec .ruby-version].include?(f)
     end
   end
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(/\Aexe\//) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel'
-  spec.add_dependency 'activesupport'
-  spec.add_dependency 'ruby-graphviz'
+  # Rails 7.1 and 8.1 are the floor and ceiling actually exercised by the CI
+  # matrix in .github/workflows/test.yml. The `< 9` ceiling is deliberately
+  # looser so consuming apps can move to a new Rails ahead of this gem; add a
+  # matrix row when the next Rails ships rather than widening this blindly.
+  spec.add_dependency 'activemodel', '>= 7.1', '< 9'
+  spec.add_dependency 'activesupport', '>= 7.1', '< 9'
+  spec.add_dependency 'ruby-graphviz', '~> 1.2'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
DfE has no RubyGems account, so the annotated tag is the release and Bundler installs straight from the git checkout. Nothing here published that fact or protected it.

Gemspec: declares the MIT licence the LICENSE file has always granted, adds source/bug-tracker/documentation metadata, and constrains the runtime dependencies. They were completely unversioned, which is the one gap consumers actually feel — Bundler resolves the gemspec during their own dependency resolution, so a consumer on Rails 6.1 got no signal at all. The range matches what the CI matrix proves: 7.1 through 8.1, with a looser `< 9` ceiling so apps can move to a new Rails ahead of this gem.

Publishing is blocked at two levels. `rake release` (defined by bundler/gem_tasks as tag + push + `gem push`) now aborts with a pointer to RELEASING.md instead of half-running; `allowed_push_host` points at an unresolvable host so a direct `gem push` cannot publish under whoever happens to be logged in. `rake build` and `rake install` are unaffected.

release.yml turns a `v*` tag into a GitHub Release: it asserts the tag matches Dfe::Wizard::VERSION (the version lives in three places, so this is the safety net), re-runs the full matrix against the tagged tree, builds the .gem as an audit artefact, and extracts the matching CHANGELOG section as the release body — failing loudly rather than publishing empty notes. Prereleases are detected from the version suffix. It uses `gh` rather than a third-party action to keep the supply chain short.

Packaged gem no longer ships TODO.md or lint config. This is cosmetic for git consumers, who get the whole checkout regardless, but the artefact attached to a Release should be clean.