### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+## [1.0.0] - 2026-08-13
+
+First stable release. The API is now frozen — subsequent breaking changes will
+require a major version.
+
+### Breaking changes
+
+Both affect code written against `1.0.0.beta`. Nothing changes for users of
+`0.1.x`, who should read the `1.0.0.beta` notes below as well.
+
+- **`predicate_caller:` is now a required keyword on `StepsProcessor::Graph.draw`.**
+  Branching predicates are resolved against an explicit object rather than
+  being guessed at, which makes it possible to keep predicates on the state
+  store and out of the wizard. Every graph wizard needs updating:
+
+      # before
+      DfE::Wizard::StepsProcessor::Graph.draw(self) do |graph|
+
+      # after
+      DfE::Wizard::StepsProcessor::Graph.draw(self, predicate_caller: state_store) do |graph|
+
+- **`StateStore` no longer uses `method_missing`.** Assigning
+  `attribute_names=` now generates real accessor methods for those attributes,
+  so attribute access is visible to `respond_to?`, appears in backtraces, and
+  does not silently swallow typos. Reading an attribute that is not declared by
+  any step raises `NoMethodError` where it previously fell through to
+  `method_missing`. Existing methods on the state store are never overwritten,
+  and `step_attributes_methods?` still turns generation off.
+
+### Added
+
+- **`CheckAnswersPresenter`** for building "check your answers" pages, with
+  `reviewable_steps`, row grouping, and a `format_value` hook for custom
+  formatting.
+- `Repository::Model`, `StepsProcessor::Base` and `StepsProcessor::Linear` are
+  now autoloaded — they previously had to be required by hand.
+- Declared supported versions: Ruby 3.2–3.4 and Rails 7.1–8.1, each combination
+  exercised by CI. The `activemodel`/`activesupport` dependencies carry a
+  version range for the first time, so incompatibilities surface during
+  `bundle install` rather than at runtime.
+- MIT licence, now also declared in the gemspec.
+
+### Fixed
+
+- Graphviz graph names are sanitised, so wizard class names containing
+  characters that are invalid in DOT no longer produce broken output.
+- Predicate resolution is applied consistently across `Graph.draw` and the
+  graph DSL; some paths previously bypassed it.
+
+### Documentation
+
+- Full README rewrite covering data flow, navigation, repositories, route
+  strategies and testing.
+- `RELEASING.md` documents the release procedure. Note that this gem is
+  distributed via GitHub tags, not RubyGems.
+
 ## [1.0.0.beta] - 2025-12-22
 
 - **New step engine**: Replaces the original linear `steps do [...] end` DSL with pluggable steps processors (linear and graph) that support branching, skipped steps, and dynamic root.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A multi-step form framework for Ruby on Rails applications.
 
-**Version**: 1.0.0.beta
+**Version**: 1.0.0
 
 ### Requirements
 
@@ -105,7 +105,7 @@ This gem is distributed via GitHub tags, not RubyGems. Pin to a tag in your
 Gemfile:
 
 ```ruby
-gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v1.0.0.beta'
+gem 'dfe-wizard', require: 'dfe/wizard', github: 'DFE-Digital/dfe-wizard', tag: 'v1.0.0'
 ```
 
 Then run:

--- a/lib/dfe/wizard/version.rb
+++ b/lib/dfe/wizard/version.rb
@@ -1,5 +1,5 @@
 module Dfe
   module Wizard
-    VERSION = '1.0.0.beta'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end


### PR DESCRIPTION
Freezes the API. The version moves in the three places that must agree — version.rb and the two README references — and the release workflow's guard fails the tag if they drift.

The CHANGELOG entry is written against what actually changed since v1.0.0.beta rather than the commit subjects, which mislead in two places. "Rename ReviewPresenter to CheckAnswersPresenter" is not a rename from a beta user's point of view: ReviewPresenter was added and renamed after the beta tag, so CheckAnswersPresenter is simply new. Conversely the genuinely disruptive change has no obvious commit — `predicate_caller:` became a required keyword on Graph.draw, which breaks every graph wizard and needed a migration example.

The other break is the state store dropping method_missing for generated accessors: undeclared attributes now raise NoMethodError instead of falling through.

"Add step access guard" is not listed — it only touched the dummy app.